### PR TITLE
Updated header logo sizing to be same as footer logos

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -9,8 +9,11 @@ const HeaderContainer = styled.div`
     font-weight: lighter;
     font-size: ${({ theme }) => theme.sizes.fonts.xl};
   }
-  .fa-bars {
+  .fa-bars,
+  .fa-bag-shopping,
+  .fa-magnifying-glass {
     cursor: pointer;
+    font-size: ${({ theme }) => theme.sizes.fonts.xl};
   }
   .fa-bag-shopping:hover,
   .fa-magnifying-glass:hover,
@@ -18,25 +21,21 @@ const HeaderContainer = styled.div`
     filter: opacity(0.7);
   }
   .fa-magnifying-glass {
-    cursor: pointer;
     margin-left: ${({ theme }) => theme.sizes.spacing.md};
-  }
-  .fa-bag-shopping {
-    cursor: pointer;
   }
 `;
 const Header = () => {
   return (
     <HeaderContainer data-testid="header">
-      <i className="fa-solid fa-bars fa-2x" data-testid="hamburger-icon"></i>
+      <i className="fa-solid fa-bars fa-1x" data-testid="hamburger-icon"></i>
       <h1>Shoply</h1>
       <div>
         <i
-          className="fa-solid fa-bag-shopping fa-2x"
+          className="fa-solid fa-bag-shopping fa-1x"
           data-testid="basket-icon"
         ></i>
         <i
-          className="fa-solid fa-magnifying-glass fa-2x"
+          className="fa-solid fa-magnifying-glass fa-1x"
           data-testid="search-icon"
         ></i>
       </div>


### PR DESCRIPTION
# Create Header

**Ticket:** [Create Header](https://trello.com/c/2U0uKuTJ/17-create-the-header)

## Description

I have resized the logo sizes at the top of the header to be the same as the footer logo's

### Screenshots

![Screenshot 2022-04-21 at 16 21 02](https://user-images.githubusercontent.com/92609413/164491618-4f82b8b2-0e06-466f-beca-8fc81c6e41cc.png)

## Effected Areas

The Areas where the logos are placed are smaller and not as large and inconsistent with the footer logos

## Developer Checklist

I have

- [X ] Made the minimum amount of change required to achieve my goal to a high standard
- [X ] Added tests that describe the change
- [ ] Created tickets for any tech debt incurred
