### PR TITLE
Feature single line input

### DIFF
--- a/src/components/general/input/Input.test.tsx
+++ b/src/components/general/input/Input.test.tsx
@@ -1,0 +1,18 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../../test-utils';
+import { Input } from '.';
+
+describe('Single line input component', () => {
+  it('renders a text input component that accepts an onChange props ', async () => {
+    const user = userEvent.setup();
+    const onChangeMock = jest.fn();
+    render(<Input onChange={onChangeMock} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+
+    await user.type(input, 'foo');
+    expect(input).toHaveValue('foo');
+    expect(onChangeMock).toBeCalledTimes(3);
+  });
+});

--- a/src/components/general/input/index.tsx
+++ b/src/components/general/input/index.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const StyledInput = styled.input`
+  border-radius: 20px;
+  border: ${({ theme }) => theme.colors.dark} solid 1px;
+  margin: ${({ theme }) => theme.sizes.spacing.sm};
+  padding: ${({ theme }) => theme.sizes.spacing.sm}
+    ${({ theme }) => theme.sizes.spacing.lg};
+  font-size: ${({ theme }) => theme.sizes.fonts.lg};
+  font-weight: 300;
+`;
+
+export const Input: React.FC<{
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}> = ({ onChange }) => {
+  return <StyledInput type="text" onChange={onChange} />;
+};

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,4 +1,14 @@
 import { ProductTiles } from '../../components/product-tiles/ProductTiles';
+import { Input } from '../../components/general/input';
 export const HomePage: React.FC = () => {
-  return <ProductTiles />;
+  return (
+    <>
+      <Input
+        onChange={(e) => {
+          console.log(e.target.value);
+        }}
+      />
+      <ProductTiles />
+    </>
+  );
 };


### PR DESCRIPTION
# Create a compositional single line Input component

**Ticket:** [Create a compositional single line Input component](https://trello.com/c/r4qahORN/67-create-a-compositional-single-line-input-component)

## Description

I have created a single line text input component in the general components folder, which requires an onChange prop. It is currently rendered on the homepage and logs the value of the input. 

### Screenshots

<img width="855" alt="Screenshot 2022-05-04 at 12 20 56" src="https://user-images.githubusercontent.com/103435833/166674295-26bc9471-3420-4540-a4a7-0502e9a85442.png">
<img width="670" alt="Screenshot 2022-05-04 at 11 22 54" src="https://user-images.githubusercontent.com/103435833/166674307-e6482b6f-01bf-494d-bca0-39b177ee718a.png">

## Effected Areas

Homepage.

## Developer Checklist

I have

- [x] Made the minimum amount of change required to achieve my goal to a high standard
- [x] Added tests that describe the change
- [ ] Created tickets for any tech debt incurred
