### PR TITLE
Added Fall back Lanuage to English

### DIFF
--- a/src/translations/i18n.tsx
+++ b/src/translations/i18n.tsx
@@ -11,6 +11,7 @@ import { TRANSLATIONS_FR } from './locales/fr';
 use(LanguageDetector)
   .use(initReactI18next)
   .init({
+    fallbackLng: 'en',
     resources: {
       en: {
         translation: TRANSLATIONS_EN,


### PR DESCRIPTION
# [Translation Bug Fix]

**Ticket:** [Translation Bug Fix](https://trello.com/c/VZUlMcu5/20-add-translations-to-the-producttile)

## Description

I added an option in the i18next file to accept a Fall back language to English so that if it does not recognise any language it will Fall back to English

## Effected Areas

Translation - i18n.tsx 

## Developer Checklist

I have

- [x] Made the minimum amount of change required to achieve my goal to a high standard
- [ ] Added tests that describe the change
- [ ] Created tickets for any tech debt incurred
