### PR TITLE
change currency to default to GBP if language isn't french, portugues…

### DIFF
--- a/src/components/product-tile/product-price/ProductPrice.tsx
+++ b/src/components/product-tile/product-price/ProductPrice.tsx
@@ -11,12 +11,12 @@ const Price: React.FC<{ price: number }> = ({ price }) => {
   const intl = useIntl();
   let currencyType;
 
-  if (intl.locale === 'en' || intl.locale === 'en-GB') {
-    currencyType = 'GBP';
+  if (intl.locale.slice(0, 2) === 'pt' || intl.locale.slice(0, 2) === 'fr') {
+    currencyType = 'EUR';
   } else if (intl.locale === 'en-US') {
     currencyType = 'USD';
   } else {
-    currencyType = 'EUR';
+    currencyType = 'GBP';
   }
   return (
     <>


### PR DESCRIPTION
…e or en-US

# Change product tile default currency formatting to GBP

**Ticket:** [Change product tile default currency formatting to GBP](https://trello.com/c/Su54YsCo/74-change-product-tile-default-currency-formatting-to-gbp)

## Description

To match translation feature, currency formatting now defaults to GBP if the locale isn't Portuguese (EUR), French (EUR) or en-US (USD).

### Screenshots


## Effected Areas

ProductPrice component 

## Developer Checklist

I have

- [x] Made the minimum amount of change required to achieve my goal to a high standard
- [ ] Added tests that describe the change
- [ ] Created tickets for any tech debt incurred
