### PR TITLE
Bugfix currency format

### DIFF
--- a/src/components/product-tile/product-price/ProductPrice.test.tsx
+++ b/src/components/product-tile/product-price/ProductPrice.test.tsx
@@ -27,7 +27,7 @@ test('when locale set to British English, price is formatted to £', () => {
 });
 
 test('when locale set to Portuguese, price is formatted to €', () => {
-  const formattedPrice = productDataMock.price.toLocaleString('pt', {
+  const formattedPrice = productDataMock.price.toLocaleString('pt-PT', {
     style: 'currency',
     currency: 'EUR',
     minimumFractionDigits: 2,

--- a/src/components/product-tile/product-price/ProductPrice.tsx
+++ b/src/components/product-tile/product-price/ProductPrice.tsx
@@ -10,17 +10,20 @@ const ProductPriceContainer = styled.h4`
 const Price: React.FC<{ price: number }> = ({ price }) => {
   const intl = useIntl();
   let currencyType;
+  let currencyLocale = 'en';
 
   if (intl.locale.slice(0, 2) === 'pt' || intl.locale.slice(0, 2) === 'fr') {
     currencyType = 'EUR';
+    currencyLocale = 'fr';
   } else if (intl.locale === 'en-US') {
     currencyType = 'USD';
   } else {
     currencyType = 'GBP';
   }
+
   return (
     <>
-      {intl.formatNumber(price, {
+      {price.toLocaleString(currencyLocale, {
         style: 'currency',
         currency: currencyType,
       })}

--- a/src/components/product-tile/product-price/ProductPrice.tsx
+++ b/src/components/product-tile/product-price/ProductPrice.tsx
@@ -7,7 +7,7 @@ const ProductPriceContainer = styled.h4`
   margin-bottom: ${({ theme }) => theme.sizes.spacing.md};
 `;
 
-type PriceLocale = 'en-GB' | 'fr-FR' | 'pt-PT';
+type PriceLocale = 'en-GB' | 'en-US' | 'fr-FR' | 'pt-PT';
 
 const Price: React.FC<{ price: number }> = ({ price }) => {
   const intl = useIntl();
@@ -19,6 +19,7 @@ const Price: React.FC<{ price: number }> = ({ price }) => {
     currencyLocale = intl.locale.slice(0, 2) === 'pt' ? 'pt-PT' : 'fr-FR';
   } else if (intl.locale === 'en-US') {
     currencyType = 'USD';
+    currencyLocale = 'en-US';
   } else {
     currencyType = 'GBP';
   }

--- a/src/components/product-tile/product-price/ProductPrice.tsx
+++ b/src/components/product-tile/product-price/ProductPrice.tsx
@@ -7,10 +7,12 @@ const ProductPriceContainer = styled.h4`
   margin-bottom: ${({ theme }) => theme.sizes.spacing.md};
 `;
 
+type PriceLocale = 'en' | 'fr' | 'pt-PT';
+
 const Price: React.FC<{ price: number }> = ({ price }) => {
   const intl = useIntl();
   let currencyType;
-  let currencyLocale = 'en';
+  let currencyLocale: PriceLocale = 'en';
 
   if (intl.locale.slice(0, 2) === 'pt' || intl.locale.slice(0, 2) === 'fr') {
     currencyType = 'EUR';

--- a/src/components/product-tile/product-price/ProductPrice.tsx
+++ b/src/components/product-tile/product-price/ProductPrice.tsx
@@ -7,16 +7,16 @@ const ProductPriceContainer = styled.h4`
   margin-bottom: ${({ theme }) => theme.sizes.spacing.md};
 `;
 
-type PriceLocale = 'en' | 'fr' | 'pt-PT';
+type PriceLocale = 'en-GB' | 'fr-FR' | 'pt-PT';
 
 const Price: React.FC<{ price: number }> = ({ price }) => {
   const intl = useIntl();
   let currencyType;
-  let currencyLocale: PriceLocale = 'en';
+  let currencyLocale: PriceLocale = 'en-GB';
 
   if (intl.locale.slice(0, 2) === 'pt' || intl.locale.slice(0, 2) === 'fr') {
     currencyType = 'EUR';
-    currencyLocale = 'fr';
+    currencyLocale = intl.locale.slice(0, 2) === 'pt' ? 'pt-PT' : 'fr-FR';
   } else if (intl.locale === 'en-US') {
     currencyType = 'USD';
   } else {


### PR DESCRIPTION
# Design Improvements to currency formatting on ProductTile

**Ticket:** [Design Improvements to currency formatting on ProductTile](https://trello.com/c/6xvylUn7/73-design-improvements-to-currency-formatting-on-producttile)
[Change product tile default currency formatting to GBP](https://trello.com/c/Su54YsCo/74-change-product-tile-default-currency-formatting-to-gbp)

## Description
Product price component - to reflect the testing feedback I've tried to combine the two tickets so that Euro and GBP formatting is more consistent. 
If user languages are set to French or Portuguese, prices will be set in Euros in the format ‘12.345,67 €’ and £ in the format ‘£12,345.67’

### Screenshots

<img width="226" alt="Screenshot 2022-05-09 at 15 16 32" src="https://user-images.githubusercontent.com/103435833/167433262-2cec4d41-2cf8-446a-8592-de6d59809e3e.png">
<img width="254" alt="Screenshot 2022-05-09 at 15 16 11" src="https://user-images.githubusercontent.com/103435833/167433276-167e708c-a26d-4e87-801c-e63039f0329a.png">


## Effected Areas

ProductPrice component

## Developer Checklist

I have

- [x] Made the minimum amount of change required to achieve my goal to a high standard
- [ ] Added tests that describe the change
- [ ] Created tickets for any tech debt incurred
