### PR TITLE
Feature fetch existing cart

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -6,3 +6,4 @@ export const API_GET_PRODUCT = (id: string): string =>
 export const API_SEARCH_PRODUCT = (searchTerm: string): string =>
   `${API_GET_PRODUCTS}?search=${searchTerm}&limit=5`;
 export const API_POST_ORDER = `${API}/orders`;
+export const API_GET_ORDER = (id: string): string => `${API}/orders/${id}`;

--- a/src/contexts/Cart.tsx
+++ b/src/contexts/Cart.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
-import { postOrder } from '../services/order.service';
-import { createCartCookie } from '../utils/cookies';
+import React, { useState, useEffect } from 'react';
+import { getOrderData, postOrder } from '../services/order.service';
+import { createCartCookie, getCartCookie } from '../utils/cookies';
 import { Product } from '../types/product';
 
 type CartItems = { id: string; name: string; quantity: number };
@@ -92,6 +92,27 @@ export const CartProvider: React.FC = ({ children }) => {
   const changeQuantity = changeQuantityFactory(setCart);
   const addItem = addItemFactory(setCart);
   const addToCart = addToCartFactory(addItem, changeQuantity, cart);
+
+  useEffect(() => {
+    const cartId = getCartCookie();
+    const getOrder = async (cartId: string) => {
+      try {
+        const order = await getOrderData(cartId);
+        const productsInOrder = order.products.map((item) => ({
+          id: item.product.id,
+          name: item.product.name,
+          quantity: item.quantity,
+        }));
+        setCart(productsInOrder);
+      } catch (err) {
+        console.log(err);
+      }
+    };
+
+    if (cartId) {
+      getOrder(cartId);
+    }
+  }, []);
 
   return (
     <CartContext.Provider

--- a/src/services/order.service.ts
+++ b/src/services/order.service.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { Order } from '../types/order';
-import { API_POST_ORDER } from '../constants/api';
+import { API_GET_ORDER, API_POST_ORDER } from '../constants/api';
 
 type PostProductOrder = {
   product: string;
@@ -11,5 +11,10 @@ export const postOrder = async (
   products: PostProductOrder[]
 ): Promise<Order> => {
   const { data } = await axios.post(API_POST_ORDER, { products });
+  return data;
+};
+
+export const getOrderData = async (id: string): Promise<Order> => {
+  const { data } = await axios.get(API_GET_ORDER(id));
   return data;
 };

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,7 +1,9 @@
 import { Product } from '../types/product';
 
+type OrderProducts = { product: Product; quantity: number; _id: 'string' };
+
 export type Order = {
-  products: Product[];
+  products: OrderProducts[];
   total: number;
   tax: number;
   id: string;

--- a/src/utils/cookies.test.ts
+++ b/src/utils/cookies.test.ts
@@ -11,12 +11,21 @@ describe('getCartCookie', () => {
   });
 
   it("returns cartId as a string when it's the only cookie", () => {
+    // with trailing semi colon
     Object.defineProperty(document, 'cookie', {
       writable: true,
       value: 'cartId=627a843ee88b85ea8e0bc181;',
     });
     const cartId = getCartCookie();
     expect(cartId).toBe('627a843ee88b85ea8e0bc181');
+
+    // without trailing semi colon
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'cartId=627a843ee88b85ea8e0bc181',
+    });
+    const cartId2 = getCartCookie();
+    expect(cartId2).toBe('627a843ee88b85ea8e0bc181');
   });
 
   it('returns empty string when no cartId cookie exists', () => {

--- a/src/utils/cookies.test.ts
+++ b/src/utils/cookies.test.ts
@@ -1,0 +1,41 @@
+import { getCartCookie } from './cookies';
+
+describe('getCartCookie', () => {
+  it('returns empty string when no cookies are available', () => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: '',
+    });
+    const cartId = getCartCookie();
+    expect(cartId).toBe(undefined);
+  });
+
+  it("returns cartId as a string when it's the only cookie", () => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'cartId=627a843ee88b85ea8e0bc181;',
+    });
+    const cartId = getCartCookie();
+    expect(cartId).toBe('627a843ee88b85ea8e0bc181');
+  });
+
+  it('returns empty string when no cartId cookie exists', () => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value:
+        'atrc=fbf4bad7-4c2c-4df6-a6ca-de1957289a53; ConstructorioID_client_id=a89bafcd-3a4c-4cee-9fbd-a42686b82ca7; atrc=fbf4bad7-4c2c-4df6-a6ca-de1957289a53; ADRUM=s=1650962998201&r=https%3A%2F%2Fwww.tesco.com%2F; _abck=1F6019AE29CDC6868CCEB22E17126BAD~0~YAAQLDcyF2Ch4PGAAQAAEptc9gd/JJsrrukOww5HY42r3VF9/uFdE+k4I6HHu9a+SMxhLFvR+wY42o3W/xjBvKvzPqCJIxhHINJ1o6Z/N3JzweJsBMZLHR/vVFCLx7YUzoPG/4uG6f8UIMsp0Li8z0v7P7F408w2VS6rL75nyzIuEagkmKQaAKC2imCXlBeypkT+uLA9/+vnaScAmDUZVNgV6tJBEmZbHJMaRS4wRsGiQwKLggJtlsN5QuWZNj8V48A970TvMrevZtPdHdyJK3POXyJrwQfQPzsMzXXlUASbDcyqw5ih65/IFN0MxMtU4lPsHW2YApwoH3kFiJt2de9SCXrRZBFnfZnIz7zXQwD5dHCEalmifNgxnemRtXDPNoN+pP3IYOtqAVciCmYmFr+3bXH2wyw=~-1~-1~-1; bm_sz=C65EAAD69B265669C9077D9AD0857D98~YAAQLDcyF2Oh4PGAAQAAEptc9g9yNA2zL8r8GkozvRELaJ4euL+BA0ZnFkM+zVkN3ygoQ26KPTN2Ph/SbdoclKAJbjdGvpcxNz4OOOsMzdptYDeu08heFqHxzp+s2XvItrNibxznTbcPtQrMh50G6zEP27/EceoUeJoZAbW++do7oxMuhvA4GYTON0qnaeMh6AR+4WnImxNK0vL8B1BvcKe8XxST7qCKa0KzAf58G2ak+L3qEuvAlTMurb2gzHEXB5jtpgay08jqsyqPbkBOJRy16XXo65Dtc7nWNCK8Q0guDw==~3223858~4534324; bm_sv=C8DA293AF496064239916E8A0CA00076~YAAQLDcyF2ih4PGAAQAAtKdc9g8QDObsA8FLDsLlszT5CDjL2Wu1DsohrRac+ocVe2f8/xKGRmYGUgUvEi/RsJ3YJt0r/VbvkMyusgIZOb6oZuRLvUkBeoqAovV+Ec/c2WN3dZ4sWg7j67phDHWBCBoKjd5A31f9o82YlIH1k0V0j8t8ip/biSH7z0vJK8N4+03Ii3oQtAZetycKBkJAt8kBSxlyZzApSnE9WIvhaSpG/SAJf7W6KbaipyxNjb0=~1',
+    });
+    const cartId = getCartCookie();
+    expect(cartId).toBe(undefined);
+  });
+
+  it('returns cartId as the correct string when there are multiple cookies', () => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value:
+        'atrc=fbf4bad7-4c2c-4df6-a6ca-de1957289a53; ConstructorioID_client_id=a89bafcd-3a4c-4cee-9fbd-a42686b82ca7; atrc=fbf4bad7-4c2c-4df6-a6ca-de1957289a53; ADRUM=s=1650962998201&r=https%3A%2F%2Fwww.tesco.com%2F; _abck=1F6019AE29CDC6868CCEB22E17126BAD~0~YAAQLDcyF2Ch4PGAAQAAEptc9gd/JJsrrukOww5HY42r3VF9/uFdE+k4I6HHu9a+SMxhLFvR+wY42o3W/xjBvKvzPqCJIxhHINJ1o6Z/N3JzweJsBMZLHR/vVFCLx7YUzoPG/4uG6f8UIMsp0Li8z0v7P7F408w2VS6rL75nyzIuEagkmKQaAKC2imCXlBeypkT+uLA9/+vnaScAmDUZVNgV6tJBEmZbHJMaRS4wRsGiQwKLggJtlsN5QuWZNj8V48A970TvMrevZtPdHdyJK3POXyJrwQfQPzsMzXXlUASbDcyqw5ih65/IFN0MxMtU4lPsHW2YApwoH3kFiJt2de9SCXrRZBFnfZnIz7zXQwD5dHCEalmifNgxnemRtXDPNoN+pP3IYOtqAVciCmYmFr+3bXH2wyw=~-1~-1~-1; cartId=627a843ee88b85ea8e0bc181; bm_sz=C65EAAD69B265669C9077D9AD0857D98~YAAQLDcyF2Oh4PGAAQAAEptc9g9yNA2zL8r8GkozvRELaJ4euL+BA0ZnFkM+zVkN3ygoQ26KPTN2Ph/SbdoclKAJbjdGvpcxNz4OOOsMzdptYDeu08heFqHxzp+s2XvItrNibxznTbcPtQrMh50G6zEP27/EceoUeJoZAbW++do7oxMuhvA4GYTON0qnaeMh6AR+4WnImxNK0vL8B1BvcKe8XxST7qCKa0KzAf58G2ak+L3qEuvAlTMurb2gzHEXB5jtpgay08jqsyqPbkBOJRy16XXo65Dtc7nWNCK8Q0guDw==~3223858~4534324; bm_sv=C8DA293AF496064239916E8A0CA00076~YAAQLDcyF2ih4PGAAQAAtKdc9g8QDObsA8FLDsLlszT5CDjL2Wu1DsohrRac+ocVe2f8/xKGRmYGUgUvEi/RsJ3YJt0r/VbvkMyusgIZOb6oZuRLvUkBeoqAovV+Ec/c2WN3dZ4sWg7j67phDHWBCBoKjd5A31f9o82YlIH1k0V0j8t8ip/biSH7z0vJK8N4+03Ii3oQtAZetycKBkJAt8kBSxlyZzApSnE9WIvhaSpG/SAJf7W6KbaipyxNjb0=~1',
+    });
+    const cartId = getCartCookie();
+    expect(cartId).toBe('627a843ee88b85ea8e0bc181');
+  });
+});

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -5,3 +5,22 @@ export const createCartCookie = (cartId: string): void => {
 
   document.cookie = `cartId=${cartId}; expires=${date.toUTCString()};`;
 };
+
+type Cookies = {
+  cartId?: string;
+};
+
+export const getCartCookie = (): string | undefined => {
+  const cookies: Cookies = document.cookie
+    .split(';')
+    .map((cookie) => cookie.split('='))
+    .reduce(
+      (prevObj, [key, value]) => ({
+        ...prevObj,
+        [key.trim()]: value,
+      }),
+      {}
+    );
+
+  return 'cartId' in cookies ? cookies.cartId : '';
+};

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -6,21 +6,6 @@ export const createCartCookie = (cartId: string): void => {
   document.cookie = `cartId=${cartId}; expires=${date.toUTCString()};`;
 };
 
-type Cookies = {
-  cartId?: string;
-};
-
 export const getCartCookie = (): string | undefined => {
-  const cookies: Cookies = document.cookie
-    .split(';')
-    .map((cookie) => cookie.split('='))
-    .reduce(
-      (prevObj, [key, value]) => ({
-        ...prevObj,
-        [key.trim()]: value,
-      }),
-      {}
-    );
-
-  return 'cartId' in cookies ? cookies.cartId : '';
+  return document.cookie.match(/cartId=([0-9a-f]+);/)?.[1];
 };

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -7,5 +7,5 @@ export const createCartCookie = (cartId: string): void => {
 };
 
 export const getCartCookie = (): string | undefined => {
-  return document.cookie.match(/cartId=([0-9a-f]+);/)?.[1];
+  return document.cookie.match(/cartId=([0-9a-f]+)/)?.[1];
 };


### PR DESCRIPTION
# Fetch existing carts by order ID cookie

**Ticket:** [Fetch existing carts by order ID cookie](https://trello.com/c/OqcB088G/84-fetch-existing-carts-by-order-id-cookie)

## Description

If a cartId exists, a get request is made using this id to fetch a users cart and then set the state of cart context, so an item in a cart will persist between refreshes.

### Screenshots

<img width="1371" alt="Screenshot 2022-05-24 at 12 05 27" src="https://user-images.githubusercontent.com/103435833/170022669-1b502075-52d7-4874-9fca-4cca0a3ce650.png">


## Effected Areas

Cart.tsx
cookies.ts
order.ts
order.service.ts
api.ts


## Developer Checklist

I have

- [x] Made the minimum amount of change required to achieve my goal to a high standard
- [ ] Added tests that describe the change
- [ ] Created tickets for any tech debt incurred
